### PR TITLE
Add Bilgewater to deck code

### DIFF
--- a/LORDeckCodes/app/index.js
+++ b/LORDeckCodes/app/index.js
@@ -11,7 +11,8 @@ const REGIONS = [
     { code: "IO", ref: "Ionia" },
     { code: "NX", ref: "Noxus" },
     { code: "PZ", ref: "PiltoverZaun" },
-    { code: "SI", ref: "ShadowIsles" }
+    { code: "SI", ref: "ShadowIsles" },
+    { code: "BW", ref: "Bilgewater" }
 ]
 
 function getCards(count, stream, raw = false) {

--- a/app/commands/CardSearch.js
+++ b/app/commands/CardSearch.js
@@ -20,7 +20,8 @@ const REGION_COLOURS = {
     "Demacia": "#d9dbcd",
     "Piltover & Zaun": "#b78354",
     "Ionia": "#b96683",
-    "Shadow Isles": "#55ccae"
+    "Shadow Isles": "#55ccae",
+    "Bilgewater": "#893423"
 };
 
 const RARITY_COLOURS = {

--- a/app/commands/DeckCode.js
+++ b/app/commands/DeckCode.js
@@ -30,7 +30,8 @@ const REGION_ICONS = {
     "Noxus": "<:noxus:634975308398723072>",
     "Ionia": "<:ionia:634975286680616990>",
     "Freljord": "<:freljord:634975264144621588>",
-    "Demacia": "<:demacia:634975236949016598>"
+    "Demacia": "<:demacia:634975236949016598>",
+    "Bilgewater": "<:bilgewater:716194321245798442>"
 }
 
 function format(deck) {


### PR DESCRIPTION
Bilgewater is currently missing from the deckcode functionality. I think it is purely missing the set code from the array.